### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/goal-tracker/security/code-scanning/1](https://github.com/xdoubleu/goal-tracker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's operations, the minimal required permission is `contents: read`, as the workflow only needs to read repository contents to build, lint, and test the code. No write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
