### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/goal-tracker/security/code-scanning/3](https://github.com/xdoubleu/goal-tracker/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimum permissions required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient for all jobs. This permission allows the workflow to read repository contents, which is necessary for actions like checking out the code and running tests.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, as none of the jobs require additional permissions beyond `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
