### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/goal-tracker/security/code-scanning/2](https://github.com/xdoubleu/goal-tracker/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's operations, the minimal required permissions are `contents: read` for accessing repository contents and `id-token: write` for uploading coverage reports to Codecov. Additional permissions, such as `contents: write`, are not required since the workflow does not modify repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
